### PR TITLE
Enhanced log value map to include id and class in its toString representation

### DIFF
--- a/src/main/java/com/arpnetworking/steno/LogValueMapFactory.java
+++ b/src/main/java/com/arpnetworking/steno/LogValueMapFactory.java
@@ -208,6 +208,34 @@ public final class LogValueMapFactory {
             return _target;
         }
 
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public String toString() {
+            final StringBuilder builder = new StringBuilder();
+            builder.append("{");
+            if (_target.isPresent()) {
+                builder.append("_id=")
+                        .append(Integer.toHexString(System.identityHashCode(_target.get())))
+                        .append(" ")
+                        .append(" _class=")
+                        .append(_target.get().getClass().getName())
+                        .append(" ");
+            }
+            for (final Map.Entry<String, Object> entry : entrySet()) {
+                builder.append(entry.getKey())
+                        .append("=")
+                        .append(entry.getValue().toString())
+                        .append(" ");
+            }
+            if (_target.isPresent() || !isEmpty()) {
+                builder.setLength(builder.length() - 1);
+            }
+            builder.append("}");
+            return builder.toString();
+        }
+
         private void readObject(final ObjectInputStream in) throws IOException, ClassNotFoundException {
             in.defaultReadObject();
             _target = Optional.empty();

--- a/src/test/java/com/arpnetworking/steno/LogValueMapFactoryTest.java
+++ b/src/test/java/com/arpnetworking/steno/LogValueMapFactoryTest.java
@@ -149,6 +149,19 @@ public class LogValueMapFactoryTest {
     }
 
     @Test
+    public void testToString() {
+        final String asString = LogValueMapFactory.builder().build().toString();
+        Assert.assertNotNull(asString);
+        Assert.assertFalse(asString.isEmpty());
+
+        final String asStringWithReference = LogValueMapFactory.builder(new Widget("foo")).build().toString();
+        Assert.assertNotNull(asStringWithReference);
+        Assert.assertFalse(asStringWithReference.isEmpty());
+        Assert.assertTrue(asStringWithReference.contains("_id="));
+        Assert.assertTrue(asStringWithReference.contains("_class=com.arpnetworking.logback.widgets.Widget"));
+    }
+
+    @Test
     public void testPrivateConstructor() throws Exception {
         final Constructor<LogValueMapFactory> constructor =
                 LogValueMapFactory.class.getDeclaredConstructor();


### PR DESCRIPTION
Classes implementing toLogValue (e.g. with @LogValue) commonly implement toString by invoking toLogValue().toString(). This review customizes the toString on LogValueMap (the result of toLogValue) to include the bean identifiers "_id" and "_class" if a target bean was specified.