### PR TITLE
Fix NPE in RateLimitLogger

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,6 +111,7 @@
     <jackson-coreutils.version>1.8</jackson-coreutils.version>
     <json-schema-core.version>1.2.5</json-schema-core.version>
     <json-schema-validator.version>2.2.6</json-schema-validator.version>
+    <jsr305.version>3.0.1</jsr305.version>
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <hamcrest.core.version>1.3</hamcrest.core.version>
     <junit.version>4.12</junit.version>
@@ -331,6 +332,11 @@
       <groupId>org.aspectj</groupId>
       <artifactId>aspectjrt</artifactId>
       <version>${aspectjrt.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+      <version>${jsr305.version}</version>
     </dependency>
 
     <!-- Test dependencies -->

--- a/src/main/java/com/arpnetworking/logback/StenoMarker.java
+++ b/src/main/java/com/arpnetworking/logback/StenoMarker.java
@@ -31,7 +31,6 @@ public final class StenoMarker {
     private static final String STENO_MAP_JSON_MARKER_NAME = "com.arpnetworking.logback.stenoMarker.map.json";
     private static final String STENO_OBJECT_MARKER_NAME = "com.arpnetworking.logback.stenoMarker.object";
     private static final String STENO_OBJECT_JSON_MARKER_NAME = "com.arpnetworking.logback.stenoMarker.object.json";
-    private static final String STENO_JSON_MARKER_NAME = "com.arpnetworking.logback.stenoMarker.json";
     private static final String STENO_LISTS_MARKER_NAME = "com.arpnetworking.logback.stenoMarker.lists";
 
     /**

--- a/src/main/java/com/arpnetworking/steno/DefaultLogBuilder.java
+++ b/src/main/java/com/arpnetworking/steno/DefaultLogBuilder.java
@@ -86,20 +86,16 @@ public class DefaultLogBuilder implements LogBuilder {
      */
     @Override
     public void log() {
-        // TODO(vkoskela): Add STENO_MAPS_MARKER and convert to it. [ISSUE-12]
-        List<String> dataKeys = null;
-        List<Object> dataValues = null;
-        List<String> contextKeys = null;
-        List<Object> contextValues = null;
+        // TODO(vkoskela): Add STENO_MAPS_MARKER and convert to it.
+        final List<String> dataKeys = new ArrayList<>();
+        final List<Object> dataValues = new ArrayList<>();
+        final List<String> contextKeys = new ArrayList<>();
+        final List<Object> contextValues = new ArrayList<>();
 
         if (_data != null) {
-            dataKeys = new ArrayList<>();
-            dataValues = new ArrayList<>();
             populateKeyValueLists(_data, dataKeys, dataValues);
         }
         if (_context != null) {
-            contextKeys = new ArrayList<>();
-            contextValues = new ArrayList<>();
             populateKeyValueLists(_context, contextKeys, contextValues);
         }
 

--- a/src/main/java/com/arpnetworking/steno/LogLevel.java
+++ b/src/main/java/com/arpnetworking/steno/LogLevel.java
@@ -18,6 +18,7 @@ package com.arpnetworking.steno;
 import com.arpnetworking.logback.StenoMarker;
 
 import java.util.List;
+import javax.annotation.Nullable;
 
 /**
  * Enumeration of log levels.
@@ -34,7 +35,7 @@ import java.util.List;
                 final String event,
                 final String[] keys,
                 final Object[] values,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.trace(StenoMarker.ARRAY_MARKER, event, keys, values, throwable);
@@ -52,7 +53,7 @@ import java.util.List;
                 final List<Object> dataValues,
                 final List<String> contextKeys,
                 final List<Object> contextValues,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.trace(StenoMarker.LISTS_MARKER, event, dataKeys, dataValues, contextKeys, contextValues, throwable);
@@ -74,7 +75,7 @@ import java.util.List;
                 final String event,
                 final String[] keys,
                 final Object[] values,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.debug(StenoMarker.ARRAY_MARKER, event, keys, values, throwable);
@@ -92,7 +93,7 @@ import java.util.List;
                 final List<Object> dataValues,
                 final List<String> contextKeys,
                 final List<Object> contextValues,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.debug(StenoMarker.LISTS_MARKER, event, dataKeys, dataValues, contextKeys, contextValues, throwable);
@@ -114,7 +115,7 @@ import java.util.List;
                 final String event,
                 final String[] keys,
                 final Object[] values,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.info(StenoMarker.ARRAY_MARKER, event, keys, values, throwable);
@@ -132,7 +133,7 @@ import java.util.List;
                 final List<Object> dataValues,
                 final List<String> contextKeys,
                 final List<Object> contextValues,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.info(StenoMarker.LISTS_MARKER, event, dataKeys, dataValues, contextKeys, contextValues, throwable);
@@ -154,7 +155,7 @@ import java.util.List;
                 final String event,
                 final String[] keys,
                 final Object[] values,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.warn(StenoMarker.ARRAY_MARKER, event, keys, values, throwable);
@@ -172,7 +173,7 @@ import java.util.List;
                 final List<Object> dataValues,
                 final List<String> contextKeys,
                 final List<Object> contextValues,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.warn(StenoMarker.LISTS_MARKER, event, dataKeys, dataValues, contextKeys, contextValues, throwable);
@@ -194,7 +195,7 @@ import java.util.List;
                 final String event,
                 final String[] keys,
                 final Object[] values,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.error(StenoMarker.ARRAY_MARKER, event, keys, values, throwable);
@@ -212,7 +213,7 @@ import java.util.List;
                 final List<Object> dataValues,
                 final List<String> contextKeys,
                 final List<Object> contextValues,
-                final Throwable throwable) {
+                @Nullable final Throwable throwable) {
             if (isEnabled(logger)) {
                 if (throwable != null) {
                     logger.error(StenoMarker.LISTS_MARKER, event, dataKeys, dataValues, contextKeys, contextValues, throwable);
@@ -233,7 +234,7 @@ import java.util.List;
             final String event,
             final String[] keys,
             final Object[] values,
-            final Throwable throwable);
+            @Nullable final Throwable throwable);
 
     public abstract void log(
             final org.slf4j.Logger logger,
@@ -242,7 +243,7 @@ import java.util.List;
             final List<Object> dataValues,
             final List<String> contextKeys,
             final List<Object> contextValues,
-            final Throwable throwable);
+            @Nullable final Throwable throwable);
 
     public abstract boolean isEnabled(final org.slf4j.Logger logger);
 }

--- a/src/main/java/com/arpnetworking/steno/Logger.java
+++ b/src/main/java/com/arpnetworking/steno/Logger.java
@@ -21,6 +21,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
+import javax.annotation.Nullable;
 
 /**
  * Logger designed for use particularly with Steno encoder. Although not
@@ -114,7 +115,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void trace(final String message, final Throwable throwable) {
+    public void trace(final String message, @Nullable final Throwable throwable) {
         log(LogLevel.TRACE, DEFAULT_EVENT, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -141,7 +142,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void trace(final String event, final String message, final Throwable throwable) {
+    public void trace(final String event, final String message, @Nullable final Throwable throwable) {
         log(LogLevel.TRACE, event, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -177,7 +178,7 @@ public class Logger {
             final String event,
             final String message,
             final Map<String, Object> data,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isTraceEnabled()) {
             LogLevel.TRACE.log(
                     getSlf4jLogger(),
@@ -238,7 +239,7 @@ public class Logger {
             final String message,
             final String[] dataKeys,
             final Object[] dataValues,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         log(
                 LogLevel.TRACE,
                 event,
@@ -287,7 +288,7 @@ public class Logger {
             final String message,
             final String dataKey1,
             final Object dataValue1,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isTraceEnabled()) {
             LogLevel.TRACE.log(
                     getSlf4jLogger(),
@@ -345,7 +346,7 @@ public class Logger {
             final String dataKey2,
             final Object dataValue1,
             final Object dataValue2,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isTraceEnabled()) {
             LogLevel.TRACE.log(
                     getSlf4jLogger(),
@@ -432,7 +433,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void debug(final String message, final Throwable throwable) {
+    public void debug(final String message, final @Nullable Throwable throwable) {
         log(LogLevel.DEBUG, DEFAULT_EVENT, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -459,7 +460,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void debug(final String event, final String message, final Throwable throwable) {
+    public void debug(final String event, final String message, @Nullable final Throwable throwable) {
         log(LogLevel.DEBUG, event, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -495,7 +496,7 @@ public class Logger {
             final String event,
             final String message,
             final Map<String, Object> data,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isDebugEnabled()) {
             LogLevel.DEBUG.log(
                     getSlf4jLogger(),
@@ -556,7 +557,7 @@ public class Logger {
             final String message,
             final String[] dataKeys,
             final Object[] dataValues,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         log(
                 LogLevel.DEBUG,
                 event,
@@ -605,7 +606,7 @@ public class Logger {
             final String message,
             final String dataKey1,
             final Object dataValue1,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isDebugEnabled()) {
             LogLevel.DEBUG.log(
                     getSlf4jLogger(),
@@ -663,7 +664,7 @@ public class Logger {
             final String dataKey2,
             final Object dataValue1,
             final Object dataValue2,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isDebugEnabled()) {
             LogLevel.DEBUG.log(
                     getSlf4jLogger(),
@@ -750,7 +751,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void info(final String message, final Throwable throwable) {
+    public void info(final String message, @Nullable final Throwable throwable) {
         log(LogLevel.INFO, DEFAULT_EVENT, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -777,7 +778,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void info(final String event, final String message, final Throwable throwable) {
+    public void info(final String event, final String message, @Nullable final Throwable throwable) {
         log(LogLevel.INFO, event, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -813,7 +814,7 @@ public class Logger {
             final String event,
             final String message,
             final Map<String, Object> data,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isInfoEnabled()) {
             LogLevel.INFO.log(
                     getSlf4jLogger(),
@@ -874,7 +875,7 @@ public class Logger {
             final String message,
             final String[] dataKeys,
             final Object[] dataValues,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         log(
                 LogLevel.INFO,
                 event,
@@ -923,7 +924,7 @@ public class Logger {
             final String message,
             final String dataKey1,
             final Object dataValue1,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isInfoEnabled()) {
             LogLevel.INFO.log(
                     getSlf4jLogger(),
@@ -981,7 +982,7 @@ public class Logger {
             final String dataKey2,
             final Object dataValue1,
             final Object dataValue2,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isInfoEnabled()) {
             LogLevel.INFO.log(
                     getSlf4jLogger(),
@@ -1069,7 +1070,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void warn(final String message, final Throwable throwable) {
+    public void warn(final String message, @Nullable final Throwable throwable) {
         log(LogLevel.WARN, DEFAULT_EVENT, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -1096,7 +1097,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void warn(final String event, final String message, final Throwable throwable) {
+    public void warn(final String event, final String message, @Nullable final Throwable throwable) {
         log(LogLevel.WARN, event, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -1132,7 +1133,7 @@ public class Logger {
             final String event,
             final String message,
             final Map<String, Object> data,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isWarnEnabled()) {
             LogLevel.WARN.log(
                     getSlf4jLogger(),
@@ -1193,7 +1194,7 @@ public class Logger {
             final String message,
             final String[] dataKeys,
             final Object[] dataValues,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         log(
                 LogLevel.WARN,
                 event,
@@ -1242,7 +1243,7 @@ public class Logger {
             final String message,
             final String dataKey1,
             final Object dataValue1,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isWarnEnabled()) {
             LogLevel.WARN.log(
                     getSlf4jLogger(),
@@ -1300,7 +1301,7 @@ public class Logger {
             final String dataKey2,
             final Object dataValue1,
             final Object dataValue2,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isWarnEnabled()) {
             LogLevel.WARN.log(
                     getSlf4jLogger(),
@@ -1387,7 +1388,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void error(final String message, final Throwable throwable) {
+    public void error(final String message, @Nullable final Throwable throwable) {
         log(LogLevel.ERROR, DEFAULT_EVENT, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -1414,7 +1415,7 @@ public class Logger {
      * @param message The message to be logged.
      * @param throwable The exception (<code>Throwable</code>) to be logged.
      */
-    public void error(final String event, final String message, final Throwable throwable) {
+    public void error(final String event, final String message, @Nullable final Throwable throwable) {
         log(LogLevel.ERROR, event, message, EMPTY_STRING_ARRAY, EMPTY_OBJECT_ARRAY, throwable);
     }
 
@@ -1450,7 +1451,7 @@ public class Logger {
             final String event,
             final String message,
             final Map<String, Object> data,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isErrorEnabled()) {
             LogLevel.ERROR.log(
                     getSlf4jLogger(),
@@ -1511,7 +1512,7 @@ public class Logger {
             final String message,
             final String[] dataKeys,
             final Object[] dataValues,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         log(
                 LogLevel.ERROR,
                 event,
@@ -1560,7 +1561,7 @@ public class Logger {
             final String message,
             final String dataKey1,
             final Object dataValue1,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isErrorEnabled()) {
             LogLevel.ERROR.log(
                     getSlf4jLogger(),
@@ -1618,7 +1619,7 @@ public class Logger {
             final String dataKey2,
             final Object dataValue1,
             final Object dataValue2,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         if (getSlf4jLogger().isErrorEnabled()) {
             LogLevel.ERROR.log(
                     getSlf4jLogger(),
@@ -1654,7 +1655,7 @@ public class Logger {
             final String message,
             final String[] dataKeys,
             final Object[] dataValues,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         level.log(
                 getSlf4jLogger(),
                 event,
@@ -1685,7 +1686,7 @@ public class Logger {
             final List<Object> dataValues,
             final List<String> contextKeys,
             final List<Object> contextValues,
-            final Throwable throwable) {
+            @Nullable final Throwable throwable) {
         level.log(
                 getSlf4jLogger(),
                 event,

--- a/src/test/java/com/arpnetworking/steno/DefaultLogBuilderTest.java
+++ b/src/test/java/com/arpnetworking/steno/DefaultLogBuilderTest.java
@@ -45,8 +45,8 @@ public class DefaultLogBuilderTest {
                 "MyEvent",
                 dataKeys,
                 dataValues,
-                null,
-                null,
+                Collections.emptyList(),
+                Collections.emptyList(),
                 EXCEPTION);
     }
 
@@ -60,10 +60,10 @@ public class DefaultLogBuilderTest {
         Mockito.verify(logger).log(
                 LogLevel.DEBUG,
                 "MyEvent",
-                null,
-                null,
-                null,
-                null,
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
+                Collections.emptyList(),
                 EXCEPTION);
     }
 
@@ -84,8 +84,8 @@ public class DefaultLogBuilderTest {
                 "MyEvent",
                 dataKeys,
                 dataValues,
-                null,
-                null,
+                Collections.emptyList(),
+                Collections.emptyList(),
                 EXCEPTION);
     }
 

--- a/src/test/java/com/arpnetworking/steno/RateLimitLoggerTest.java
+++ b/src/test/java/com/arpnetworking/steno/RateLimitLoggerTest.java
@@ -32,6 +32,7 @@ import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -57,8 +58,8 @@ public class RateLimitLoggerTest {
                 null,
                 Arrays.asList("message", "_skipped", "_lastLogTime"),
                 Arrays.asList("m", 0, null),
-                null,
-                null);
+                Collections.emptyList(),
+                Collections.emptyList());
     }
 
     @Test
@@ -70,8 +71,8 @@ public class RateLimitLoggerTest {
                 null,
                 Arrays.asList("message", "_skipped", "_lastLogTime"),
                 Arrays.asList("m1", 0, null),
-                null,
-                null);
+                Collections.emptyList(),
+                Collections.emptyList());
 
         rateLimitLogger.info().setMessage("m2").log();
         Mockito.verify(_slf4jLogger, Mockito.atLeastOnce()).isInfoEnabled();
@@ -90,8 +91,8 @@ public class RateLimitLoggerTest {
                 null,
                 Arrays.asList("message", "_skipped", "_lastLogTime"),
                 Arrays.asList("m1", 0, null),
-                null,
-                null);
+                Collections.emptyList(),
+                Collections.emptyList());
 
         Mockito.verifyNoMoreInteractions(_slf4jLogger);
         Thread.sleep(500);
@@ -117,8 +118,8 @@ public class RateLimitLoggerTest {
                                 Matchers.hasItem("m4"),
                                 Matchers.hasItem(1),
                                 Matchers.hasItem(isBetween(beforeLastLog, afterLastLog)))),
-                Mockito.argThat(Matchers.nullValue(List.class)),
-                Mockito.argThat(Matchers.nullValue(List.class)));
+                Mockito.argThat(Matchers.equalTo(Collections.emptyList())),
+                Mockito.argThat(Matchers.equalTo(Collections.emptyList())));
     }
 
     @Test
@@ -180,6 +181,19 @@ public class RateLimitLoggerTest {
                                 Matchers.<Object>equalTo("m4"),
                                 Matchers.<Object>equalTo(1),
                                 isBetween(beforeLastLog, afterLastLog)})));
+    }
+
+    @Test
+    public void testLogBuilderWithEmptyData() {
+        final Logger rateLimitLogger = new RateLimitLogger(_slf4jLogger, Duration.ofMinutes(1), Clock.systemUTC());
+        rateLimitLogger.info().setEvent("m").log();
+        Mockito.verify(_slf4jLogger).info(
+                StenoMarker.LISTS_MARKER,
+                "m",
+                Arrays.asList("_skipped", "_lastLogTime"),
+                Arrays.asList(0, null),
+                Collections.emptyList(),
+                Collections.emptyList());
     }
 
     private static Matcher<Instant> isBetween(final Instant before, final Instant after) {


### PR DESCRIPTION
Stop passing null lists for empty data or context key/value lists to the logger. Annotated the only nullable parameter in the APIs which is the throwable. This is intended to accomplish the same goals #45 but by removing the nulls from the callpath instead of working around them. In fact, this PR includes the test from #45. 

@cybermaak does this address your use case in its entirety?