### PR TITLE
Fix Size Based Rotation

### DIFF
--- a/src/main/java/ch/qos/logback/core/rolling/helper/CustomSizeAndTimeBasedArchiveRemover.java
+++ b/src/main/java/ch/qos/logback/core/rolling/helper/CustomSizeAndTimeBasedArchiveRemover.java
@@ -1,0 +1,128 @@
+/**
+ * Copyright 2016 Inscope Metrics Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.rolling.helper;
+
+import ch.qos.logback.core.CoreConstants;
+import ch.qos.logback.core.util.FileSize;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.Date;
+
+/**
+ * This is a customization of the <code>SizeAndTimeBasedArchiveRemover</code>
+ * to enforce total size on each clean and to count all files not just periods.
+ *
+ * @author Ville Koskela (ville dot koskela at inscopemetrics dot com)
+ * @since 1.16.1
+ */
+public class CustomSizeAndTimeBasedArchiveRemover extends SizeAndTimeBasedArchiveRemover {
+
+    /**
+     * Public constructor.
+     *
+     * @param fileNamePattern The <code>FileNamePattern</code> from the <code>TimeBasedRollingPolicy</code>.
+     * @param rollingCalendar The <code>RollingCalendar</code> from the <code>SizeAndTimeBasedFNATP</code>.
+     */
+    public CustomSizeAndTimeBasedArchiveRemover(
+            final FileNamePattern fileNamePattern,
+            final RollingCalendar rollingCalendar) {
+        super(fileNamePattern, rollingCalendar);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void clean(final Date now) {
+        super.clean(now);
+        if (_totalSizeCap != CoreConstants.UNBOUND_TOTAL_SIZE && _totalSizeCap > 0) {
+            capTotalSize(now);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setTotalSizeCap(final long totalSizeCap) {
+        super.setTotalSizeCap(totalSizeCap);
+        _totalSizeCap = totalSizeCap;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setMaxHistory(final int maxHistory) {
+        super.setMaxHistory(maxHistory);
+        _maxHistory = maxHistory;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    void capTotalSize(final Date now) {
+        int totalSize = 0;
+        int totalFilesRemoved = 0;
+        int totalBytesRemoved = 0;
+        int fileIndex = 0;
+        for (int offset = 0; offset < _maxHistory; ++offset) {
+            final Date date = rc.getEndOfNextNthPeriod(now, -offset);
+            final File[] matchingFileArray = getFilesInPeriod(date);
+            descendingSortByLastModified(matchingFileArray);
+            for (final File file : matchingFileArray) {
+                final long fileSizeInBytes = file.length();
+                if (totalSize + fileSizeInBytes > _totalSizeCap) {
+                    if (fileIndex >= UNTOUCHABLE_ARCHIVE_FILE_COUNT) {
+                        addInfo(
+                                String.format(
+                                        "Deleting [%s] of size %s",
+                                        file,
+                                        new FileSize(fileSizeInBytes)));
+                        totalBytesRemoved += fileSizeInBytes;
+                        ++totalFilesRemoved;
+                        if (!file.delete()) {
+                            addWarn(
+                                    String.format(
+                                            "Deleting [%s] failed.",
+                                            file));
+                        }
+                    } else {
+                        addWarn(
+                                String.format(
+                                        "Skipping [%s] of size %s as it is one of the two newest log achives.",
+                                        file,
+                                        new FileSize(fileSizeInBytes)));
+                    }
+                }
+                totalSize += fileSizeInBytes;
+                ++fileIndex;
+            }
+        }
+        addInfo(String.format("Removed %d files totalling %s", totalFilesRemoved, new FileSize(totalBytesRemoved)));
+    }
+
+    private void descendingSortByLastModified(final File[] matchingFileArray) {
+        Arrays.sort(matchingFileArray, (f1, f2) -> Long.compare(f2.lastModified(), f1.lastModified()));
+    }
+
+    private long _totalSizeCap;
+    private int _maxHistory;
+
+    private static final int UNTOUCHABLE_ARCHIVE_FILE_COUNT = 2;
+}

--- a/src/main/java/com/arpnetworking/logback/SizeAndRandomizedTimeBasedFNATP.java
+++ b/src/main/java/com/arpnetworking/logback/SizeAndRandomizedTimeBasedFNATP.java
@@ -19,6 +19,9 @@ import ch.qos.logback.core.Context;
 import ch.qos.logback.core.joran.spi.NoAutoStart;
 import ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP;
 import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
+import ch.qos.logback.core.rolling.helper.ArchiveRemover;
+import ch.qos.logback.core.rolling.helper.CustomSizeAndTimeBasedArchiveRemover;
+import ch.qos.logback.core.rolling.helper.FileNamePattern;
 
 import java.util.Date;
 
@@ -155,6 +158,16 @@ public class SizeAndRandomizedTimeBasedFNATP<E> extends SizeAndTimeBasedFNATP<E>
     protected void setDateInCurrentPeriod(final long now) {
         _randomizedTimeBasedFNATP.getDateInCurrentPeriod().setTime(now);
         super.setDateInCurrentPeriod(now);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected ArchiveRemover createArchiveRemover() {
+        return new CustomSizeAndTimeBasedArchiveRemover(
+                new FileNamePattern(this.tbrp.getFileNamePattern(), this.context),
+                this.rc);
     }
 
     /* package private */ long getNextCheck() {

--- a/src/test/java/com/arpnetworking/logback/SizeAndRandomizedTimeBasedFNATPTest.java
+++ b/src/test/java/com/arpnetworking/logback/SizeAndRandomizedTimeBasedFNATPTest.java
@@ -19,6 +19,8 @@ import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.LoggingEvent;
 import ch.qos.logback.core.rolling.RollingFileAppender;
 import ch.qos.logback.core.rolling.TimeBasedRollingPolicy;
+import ch.qos.logback.core.rolling.helper.ArchiveRemover;
+import ch.qos.logback.core.rolling.helper.CustomSizeAndTimeBasedArchiveRemover;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -155,6 +157,12 @@ public class SizeAndRandomizedTimeBasedFNATPTest {
         Mockito.verify(_wrappedPolicy).computeNextCheck();
         Mockito.verify(_wrappedPolicy).getNextCheck();
         Assert.assertEquals(123L, _triggeringPolicy.getNextCheck());
+    }
+
+    @Test
+    public void testCreateArchiveRemover() {
+        final ArchiveRemover archiveRemover = _triggeringPolicy.createArchiveRemover();
+        Assert.assertTrue(archiveRemover instanceof CustomSizeAndTimeBasedArchiveRemover);
     }
 
     private void resetMock(final Object mock) {


### PR DESCRIPTION
Restoring new version of CustomSizeAndTimeBasedArchiveRemover to fix new problems with Logback's size based rotation. Originally introduced in #24 and then removed in #44, this new version fixes issues with the latest 1.1.7 release of Logback.