### PR TITLE
Upgrading to logback v1.2.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -115,7 +115,7 @@
     <hamcrest.version>2.0.0.0</hamcrest.version>
     <hamcrest.core.version>1.3</hamcrest.core.version>
     <junit.version>4.12</junit.version>
-    <logback.version>1.1.7</logback.version>
+    <logback.version>1.2.1</logback.version>
     <mockito.version>1.10.19</mockito.version>
     <slf4j.version>1.7.21</slf4j.version>
 

--- a/src/main/java/ch/qos/logback/core/rolling/helper/CustomSizeAndTimeBasedArchiveRemover.java
+++ b/src/main/java/ch/qos/logback/core/rolling/helper/CustomSizeAndTimeBasedArchiveRemover.java
@@ -49,7 +49,7 @@ public class CustomSizeAndTimeBasedArchiveRemover extends SizeAndTimeBasedArchiv
     @Override
     public void clean(final Date now) {
         super.clean(now);
-        if (_totalSizeCap != CoreConstants.UNBOUND_TOTAL_SIZE && _totalSizeCap > 0) {
+        if (_totalSizeCap != CoreConstants.UNBOUNDED_TOTAL_SIZE_CAP && _totalSizeCap > 0) {
             capTotalSize(now);
         }
     }

--- a/src/main/java/com/arpnetworking/logback/BaseLoggingEncoder.java
+++ b/src/main/java/com/arpnetworking/logback/BaseLoggingEncoder.java
@@ -19,9 +19,11 @@ import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.encoder.LayoutWrappingEncoder;
 import org.slf4j.Marker;
 
-import java.io.IOException;
+import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+
 import javax.annotation.Nullable;
 
 /**
@@ -36,7 +38,15 @@ public abstract class BaseLoggingEncoder extends LayoutWrappingEncoder<ILoggingE
      * {@inheritDoc}
      */
     @Override
-    public void doEncode(final ILoggingEvent event) throws IOException {
+    public Charset getCharset() {
+        return Charset.defaultCharset();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public byte[] encode(final ILoggingEvent event) {
         final Marker marker = event.getMarker();
         final String name = event.getMessage();
         final Object[] argumentArray = event.getArgumentArray();
@@ -47,12 +57,11 @@ public abstract class BaseLoggingEncoder extends LayoutWrappingEncoder<ILoggingE
         } catch (final EncodingException ee) {
             output = encodeAsString(event, ee);
         }
+        return encodeString(output);
+    }
 
-        outputStream.write(output.getBytes("UTF8"));
-
-        if (isImmediateFlush()) {
-            outputStream.flush();
-        }
+    byte[] encodeString(final String s) {
+            return s.getBytes(Optional.ofNullable(getCharset()).orElse(Charset.defaultCharset()));
     }
 
     /**

--- a/src/main/java/com/arpnetworking/logback/BaseLoggingEncoder.java
+++ b/src/main/java/com/arpnetworking/logback/BaseLoggingEncoder.java
@@ -39,7 +39,7 @@ public abstract class BaseLoggingEncoder extends LayoutWrappingEncoder<ILoggingE
      */
     @Override
     public Charset getCharset() {
-        return Charset.defaultCharset();
+        return Charset.forName("UTF-8");
     }
 
     /**

--- a/src/test/java/com/arpnetworking/logback/BaseLoggingEncoderTest.java
+++ b/src/test/java/com/arpnetworking/logback/BaseLoggingEncoderTest.java
@@ -18,11 +18,9 @@ package com.arpnetworking.logback;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import org.junit.Assert;
 import org.junit.Test;
-import org.mockito.Mockito;
 import org.slf4j.Marker;
 import org.slf4j.helpers.BasicMarkerFactory;
 
-import java.io.OutputStream;
 import java.util.List;
 import java.util.Map;
 
@@ -109,29 +107,6 @@ public class BaseLoggingEncoderTest {
         Assert.assertFalse(_encoder.isObjectJsonStenoEvent(StenoMarker.ARRAY_MARKER));
         Assert.assertFalse(_encoder.isObjectJsonStenoEvent(StenoMarker.ARRAY_JSON_MARKER));
         Assert.assertFalse(_encoder.isObjectJsonStenoEvent(StenoMarker.OBJECT_MARKER));
-    }
-
-    @Test
-    public void testImmediateFlushEnabled() throws Exception {
-        final OutputStream outputStream = Mockito.mock(OutputStream.class);
-        _encoder.init(outputStream);
-
-        final ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
-        _encoder.doEncode(event);
-
-        Mockito.verify(outputStream).flush();
-    }
-
-    @Test
-    public void testImmediateFlushDisabled() throws Exception {
-        final OutputStream outputStream = Mockito.mock(OutputStream.class);
-        _encoder.init(outputStream);
-        _encoder.setImmediateFlush(false);
-
-        final ILoggingEvent event = Mockito.mock(ILoggingEvent.class);
-        _encoder.doEncode(event);
-
-        Mockito.verify(outputStream, Mockito.never()).flush();
     }
 
     private BaseLoggingEncoder _encoder = new TestLoggingEncoder();

--- a/src/test/java/com/arpnetworking/logback/KeyValueEncoderTest.java
+++ b/src/test/java/com/arpnetworking/logback/KeyValueEncoderTest.java
@@ -56,7 +56,7 @@ public class KeyValueEncoderTest {
         _baos = new ByteArrayOutputStream();
         _encoder = new KeyValueEncoder();
         _encoder.setImmediateFlush(true);
-        _encoder.init(_baos);
+
         final PatternLayout layout = new PatternLayout();
         layout.setPattern("[%d{dd MMM yyyy HH:mm:ss.SSS,UTC}] %t - %m%n");
         layout.setContext(_context);
@@ -79,8 +79,9 @@ public class KeyValueEncoderTest {
         argArray[0] = new String[] {"key1", "key2"};
         argArray[1] = new Object[] {Integer.valueOf(1234), "foo"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArray.log", logOutput);
     }
 
@@ -98,8 +99,9 @@ public class KeyValueEncoderTest {
         argArray[1] = new Object[] {Integer.valueOf(1234), "foo"};
         event.setArgumentArray(argArray);
         _encoder.setLayout(_throwingLayout);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArrayThrowsException.log", logOutput);
     }
 
@@ -115,8 +117,9 @@ public class KeyValueEncoderTest {
         argArray[0] = new String[] {"key1", "key2"};
         argArray[1] = new Object[] {Integer.valueOf(1234), "foo"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArrayDefaultName.log", logOutput);
     }
 
@@ -134,8 +137,9 @@ public class KeyValueEncoderTest {
         argArray[0] = new String[] {"key1", "key2"};
         argArray[1] = new Object[] {Integer.valueOf(1234), "foo"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArrayCustomDefaultName.log", logOutput);
     }
 
@@ -152,8 +156,9 @@ public class KeyValueEncoderTest {
         argArray[0] = new String[] {"key1", "key2"};
         argArray[1] = new String[] {"{\"foo\":\"bar\"}", "[\"foo\":\"bar\"]"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArrayJson.log", logOutput);
     }
 
@@ -171,8 +176,9 @@ public class KeyValueEncoderTest {
         argArray[1] = new String[] {"{\"foo\":\"bar\"}", "[\"foo\":\"bar\"]"};
         event.setArgumentArray(argArray);
         _encoder.setLayout(_throwingLayout);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArrayJsonThrowsException.log", logOutput);
     }
 
@@ -189,8 +195,9 @@ public class KeyValueEncoderTest {
         argArray[0] = new String[] {"key1", "key2"};
         argArray[1] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArrayJsonNullValues.log", logOutput);
     }
 
@@ -209,8 +216,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = map;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeMap.log", logOutput);
     }
 
@@ -230,8 +238,9 @@ public class KeyValueEncoderTest {
         argArray[0] = map;
         event.setArgumentArray(argArray);
         _encoder.setLayout(_throwingLayout);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeMapThrowsException.log", logOutput);
     }
 
@@ -247,8 +256,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeMapNullMap.log", logOutput);
     }
 
@@ -267,8 +277,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = map;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeMapJson.log", logOutput);
     }
 
@@ -288,8 +299,9 @@ public class KeyValueEncoderTest {
         argArray[0] = map;
         event.setArgumentArray(argArray);
         _encoder.setLayout(_throwingLayout);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeMapJsonThrowsException.log", logOutput);
     }
 
@@ -305,8 +317,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeMapJsonNullMap.log", logOutput);
     }
 
@@ -322,8 +335,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = new Widget("foo");
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeObject.log", logOutput);
     }
 
@@ -340,8 +354,9 @@ public class KeyValueEncoderTest {
         argArray[0] = new Widget("foo");
         event.setArgumentArray(argArray);
         _encoder.setLayout(_throwingLayout);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeObjectThrowsException.log", logOutput);
     }
 
@@ -357,8 +372,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeObjectNull.log", logOutput);
     }
 
@@ -374,8 +390,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = "{\"key\":\"value\"}";
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeObjectJson.log", logOutput);
     }
 
@@ -392,8 +409,9 @@ public class KeyValueEncoderTest {
         argArray[0] = "{\"key\":\"value\"}";
         event.setArgumentArray(argArray);
         _encoder.setLayout(_throwingLayout);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeObjectJsonThrowsException.log", logOutput);
     }
 
@@ -409,8 +427,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeObjectJsonNull.log", logOutput);
     }
 
@@ -429,8 +448,9 @@ public class KeyValueEncoderTest {
         argArray[2] = Collections.singletonList("contextKey");
         argArray[3] = Collections.singletonList("contextValue");
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeLists.log", logOutput);
     }
 
@@ -450,8 +470,9 @@ public class KeyValueEncoderTest {
         argArray[3] = Collections.singletonList("contextValue");
         event.setArgumentArray(argArray);
         _encoder.setLayout(_throwingLayout);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeListsThrowsException.log", logOutput);
     }
 
@@ -470,8 +491,9 @@ public class KeyValueEncoderTest {
         argArray[2] = Collections.emptyList();
         argArray[3] = Collections.emptyList();
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeListsEmpty.log", logOutput);
     }
 
@@ -490,8 +512,9 @@ public class KeyValueEncoderTest {
         argArray[2] = null;
         argArray[3] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeListsNull.log", logOutput);
     }
 
@@ -510,8 +533,9 @@ public class KeyValueEncoderTest {
         argArray[2] = Collections.singletonList("contextKey");
         argArray[3] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeListsNullValues.log", logOutput);
     }
 
@@ -530,8 +554,9 @@ public class KeyValueEncoderTest {
         argArray[2] = null;
         argArray[3] = Collections.singletonList("contextValue");
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeListsNullMismatch.log", logOutput);
     }
 
@@ -546,8 +571,9 @@ public class KeyValueEncoderTest {
         final Object[] argArray = new Object[2];
         argArray[0] = "bar";
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeStandardEvent.log", logOutput);
     }
 
@@ -563,8 +589,9 @@ public class KeyValueEncoderTest {
         argArray[0] = "bar";
         event.setArgumentArray(argArray);
         _encoder.setLayout(_throwingLayout);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeStandardEventThrowsException.log", logOutput);
     }
 
@@ -581,8 +608,9 @@ public class KeyValueEncoderTest {
         argArray[0] = new String[] {};
         argArray[1] = new Object[] {};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArrayEmptyKeysAndValues.log", logOutput);
     }
 
@@ -599,8 +627,9 @@ public class KeyValueEncoderTest {
         argArray[0] = null;
         argArray[1] = new Object[] {Integer.valueOf(1234), "foo"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is how you do it.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("KeyValueEncoderTest.testEncodeArrayStringNullKeys.log", logOutput);
     }
 

--- a/src/test/java/com/arpnetworking/logback/StenoEncoderTest.java
+++ b/src/test/java/com/arpnetworking/logback/StenoEncoderTest.java
@@ -81,7 +81,7 @@ public class StenoEncoderTest {
         _encoder.setRedactEnabled(false);
         _encoder.setRedactNull(true);
         _encoder.setImmediateFlush(true);
-        _encoder.init(_baos);
+
         _encoder.setContext(_context);
         _encoder.addJacksonModule(_javaTimeModule);
         _encoder.start();
@@ -99,8 +99,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{"key1", "key2"};
         argArray[1] = new Object[]{Integer.valueOf(1234), "foo"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArray.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -118,8 +119,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{};
         argArray[1] = new Object[]{};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayWithException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -137,8 +139,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{};
         argArray[1] = new Object[]{};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayWithCausedException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -158,8 +161,11 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{};
         argArray[1] = new Object[]{};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayWithSuppressedException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -184,8 +190,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{};
         argArray[1] = new Object[]{};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayWithNullSuppressedException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -204,8 +211,9 @@ public class StenoEncoderTest {
         argArray[1] = new Object[]{date, new Redacted("string", 1L)};
         event.setArgumentArray(argArray);
         _encoder.setRedactEnabled(true);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayComplexValue.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -222,8 +230,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{"key1", "key2"};
         argArray[1] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayNullValues.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -240,8 +249,9 @@ public class StenoEncoderTest {
         argArray[0] = null;
         argArray[1] = new Object[]{Integer.valueOf(1234), "foo"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayNullKeys.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -262,9 +272,9 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new IOException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayThrowsIOException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -281,8 +291,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{"key1", "key2"};
         argArray[1] = new String[]{"{\"foo\":\"bar\"}", "[\"foo\",\"bar\"]"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayJson.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -299,8 +310,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{"key1", "key2"};
         argArray[1] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayJsonNullValues.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -317,8 +329,9 @@ public class StenoEncoderTest {
         argArray[0] = null;
         argArray[1] = new String[]{"{\"foo\":\"bar\"}", "[\"foo\",\"bar\"]"};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayJsonNullKeys.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -339,9 +352,9 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new IOException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeArrayJsonThrowsIOException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -360,8 +373,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = map;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMap.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -380,8 +394,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = map;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMapComplexValue.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -400,8 +415,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = map;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMapNullValues.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -417,8 +433,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMapNullMap.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -441,9 +458,9 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new IOException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMapThrowsIOException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -462,8 +479,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = map;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMapJson.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -482,8 +500,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = map;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMapJsonNullValues.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -499,8 +518,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMapJsonNullMap.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -523,9 +543,9 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new IOException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeMapJsonThrowsIOException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -541,8 +561,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = new Widget("foo");
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObject.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -561,8 +582,9 @@ public class StenoEncoderTest {
         Assert.assertTrue(_encoder.isSafe());
         _encoder.setSafe(false);
         Assert.assertFalse(_encoder.isSafe());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObjectUnsafe.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -581,8 +603,9 @@ public class StenoEncoderTest {
         Assert.assertFalse(_encoder.isInjectBeanIdentifier());
         _encoder.setInjectBeanIdentifier(true);
         Assert.assertTrue(_encoder.isInjectBeanIdentifier());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObjectWithInjectBeanIdentity.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -604,8 +627,9 @@ public class StenoEncoderTest {
         Assert.assertTrue(_encoder.isSafe());
         _encoder.setSafe(false);
         Assert.assertFalse(_encoder.isSafe());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObjectWithInjectBeanIdentityUnsafe.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -621,8 +645,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = new WidgetWithLoggable("foo");
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeLoggableObject.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -641,8 +666,9 @@ public class StenoEncoderTest {
         Assert.assertFalse(_encoder.isInjectBeanIdentifier());
         _encoder.setInjectBeanIdentifier(true);
         Assert.assertTrue(_encoder.isInjectBeanIdentifier());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeLoggableObjectWithInjectBeanIdentity.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -658,8 +684,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = new WidgetWithLogValue("foo");
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeLogValueObject.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -678,8 +705,9 @@ public class StenoEncoderTest {
         Assert.assertFalse(_encoder.isInjectBeanIdentifier());
         _encoder.setInjectBeanIdentifier(true);
         Assert.assertTrue(_encoder.isInjectBeanIdentifier());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeLogValueObjectWithInjectBeanIdentity.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -704,9 +732,9 @@ public class StenoEncoderTest {
                 .writeValueAsString(Mockito.any(Object.class));
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObjectThrowsIOException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -722,8 +750,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObjectNull.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -739,8 +768,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = "{\"key\":\"value\"}";
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObjectJson.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -760,9 +790,9 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new IOException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObjectJsonThrowsIOException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -778,8 +808,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeObjectJsonNull.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -798,8 +829,9 @@ public class StenoEncoderTest {
         argArray[2] = Arrays.asList("CONTEXT_KEY1", "CONTEXT_KEY2");
         argArray[3] = Arrays.asList("bar", Double.valueOf(1.23));
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeLists.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -822,9 +854,9 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new IOException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeListsThrowsIOException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -843,8 +875,9 @@ public class StenoEncoderTest {
         argArray[2] = Collections.emptyList();
         argArray[3] = Collections.emptyList();
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeListsEmpty.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -863,8 +896,9 @@ public class StenoEncoderTest {
         argArray[2] = null;
         argArray[3] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeListsEmpty.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -883,8 +917,9 @@ public class StenoEncoderTest {
         argArray[2] = Collections.singletonList("CONTEXT_KEY1");
         argArray[3] = Arrays.asList("bar", Double.valueOf(1.23));
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeListsValuesWithoutKeys.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -903,8 +938,9 @@ public class StenoEncoderTest {
         argArray[2] = Arrays.asList("CONTEXT_KEY1", "CONTEXT_KEY2");
         argArray[3] = null;
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeListsNullValues.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -924,8 +960,9 @@ public class StenoEncoderTest {
         argArray[2] = Collections.singletonList("CONTEXT_KEY1");
         argArray[3] = Collections.singletonList(date);
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeListsComplexValue.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -941,8 +978,9 @@ public class StenoEncoderTest {
         final Object[] argArray = new Object[1];
         argArray[0] = "bar";
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeStandardEvent.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -962,9 +1000,9 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new IOException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeStandardEventThrowsIOException.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -985,8 +1023,9 @@ public class StenoEncoderTest {
         Assert.assertTrue(_encoder.isInjectContextHost());
         Assert.assertTrue(_encoder.isInjectContextThread());
         Assert.assertTrue(_encoder.isInjectContextProcess());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeStandardEventWithCustomEventName.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1006,8 +1045,9 @@ public class StenoEncoderTest {
         _encoder.setInjectContextLogger(true);
         _encoder.setCompressLoggerName(true);
         Assert.assertTrue(_encoder.isCompressLoggerName());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeStandardEventWithCompressedLoggerName.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1034,8 +1074,9 @@ public class StenoEncoderTest {
         Assert.assertFalse(_encoder.isInjectContextProcess());
         _encoder.setInjectContextThread(false);
         Assert.assertFalse(_encoder.isInjectContextThread());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeStandardEventWithSuppressDefaultContext.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1056,8 +1097,9 @@ public class StenoEncoderTest {
         Assert.assertEquals("MDC_KEY", _encoder.iteratorForInjectContextMdc().next());
         Assert.assertTrue(_encoder.isInjectContextMdc("MDC_KEY"));
         Assert.assertFalse(_encoder.isInjectContextMdc("FOO_BAR"));
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeStandardEventWithMdcProperties.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1095,8 +1137,9 @@ public class StenoEncoderTest {
         Assert.assertTrue(_encoder.isInjectContextLogger());
         _encoder.setInjectContextMethod(true);
         Assert.assertTrue(_encoder.isInjectContextMethod());
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeStandardEventWithIncludeOptionalContext.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1118,8 +1161,9 @@ public class StenoEncoderTest {
         _encoder.setRedactNull(false);
         _encoder.setRedactNull(true);
         _encoder.setRedactEnabled(false);
-        _encoder.doEncode(event);
-        final String fullLogOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String fullLogOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         Assert.assertFalse(_encoder.isRedactEnabled());
         assertOutput("StenoEncoderTest.testRedactSettings.1.json", fullLogOutput);
         assertMatchesJsonSchema(fullLogOutput);
@@ -1127,32 +1171,36 @@ public class StenoEncoderTest {
         _encoder.setRedactEnabled(true);
         _encoder.setRedactEnabled(false);
         _encoder.setRedactNull(false);
-        _encoder.doEncode(event);
-        final String nonRedactedWithNullLogOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String nonRedactedWithNullLogOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         Assert.assertFalse(_encoder.isRedactNull());
         assertOutput("StenoEncoderTest.testRedactSettings.2.json", nonRedactedWithNullLogOutput);
         assertMatchesJsonSchema(nonRedactedWithNullLogOutput);
         _baos.reset();
         _encoder.setRedactEnabled(true);
         _encoder.setRedactNull(true);
-        _encoder.doEncode(event);
-        final String redactedLogOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String redactedLogOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         Assert.assertTrue(_encoder.isRedactEnabled());
         assertOutput("StenoEncoderTest.testRedactSettings.3.json", redactedLogOutput);
         assertMatchesJsonSchema(redactedLogOutput);
         _baos.reset();
         _encoder.setRedactEnabled(true);
         _encoder.setRedactNull(true);
-        _encoder.doEncode(event);
-        final String redactedLogOutput2 = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String redactedLogOutput2 = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         Assert.assertTrue(_encoder.isRedactEnabled());
         assertOutput("StenoEncoderTest.testRedactSettings.4.json", redactedLogOutput2);
         assertMatchesJsonSchema(redactedLogOutput2);
         _baos.reset();
         _encoder.setRedactEnabled(true);
         _encoder.setRedactNull(false);
-        _encoder.doEncode(event);
-        final String redactedWithNullLogOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String redactedWithNullLogOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         Assert.assertFalse(_encoder.isRedactNull());
         assertOutput("StenoEncoderTest.testRedactSettings.5.json", redactedWithNullLogOutput);
         assertMatchesJsonSchema(redactedWithNullLogOutput);
@@ -1173,8 +1221,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{"key1", "logValue"};
         argArray[1] = new Object[]{date, new WidgetWithLogValue("FooBar!")};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeLogValue.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1191,8 +1240,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{"enum"};
         argArray[1] = new Object[]{DayOfWeek.FRIDAY};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeEnumeration.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1211,8 +1261,9 @@ public class StenoEncoderTest {
         argArray[0] = new String[]{"jsonNode"};
         argArray[1] = new Object[]{jsonNode};
         event.setArgumentArray(argArray);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testEncodeJsonNode.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1247,12 +1298,13 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new RuntimeException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
+
         _encoder.setInjectContextHost(false);
         _encoder.setInjectContextProcess(false);
         _encoder.setInjectContextThread(false);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testSafeContextWithSuppressDefaultContext.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1273,14 +1325,15 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new RuntimeException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
+
         _encoder.setInjectContextHost(false);
         _encoder.setInjectContextProcess(false);
         _encoder.setInjectContextThread(false);
         MDC.put("MDC_KEY", "MDC_VALUE");
         _encoder.addInjectContextMdc("MDC_KEY");
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testSafeContextWithMdcProperties.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1306,7 +1359,7 @@ public class StenoEncoderTest {
         final JsonFactory jsonFactory = Mockito.mock(JsonFactory.class);
         Mockito.doThrow(new RuntimeException("Mock Failure")).when(jsonFactory).createGenerator(Mockito.any(Writer.class));
         _encoder = new StenoEncoder(jsonFactory, objectMapper);
-        _encoder.init(_baos);
+
         _encoder.setInjectContextHost(false);
         _encoder.setInjectContextProcess(false);
         _encoder.setInjectContextThread(false);
@@ -1316,8 +1369,9 @@ public class StenoEncoderTest {
         _encoder.setInjectContextLine(true);
         _encoder.setInjectContextLogger(true);
         _encoder.setInjectContextMethod(true);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testSafeContextWithIncludeOptionalContext.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1358,9 +1412,10 @@ public class StenoEncoderTest {
         _encoder.setInjectContextProcess(false);
         _encoder.setInjectContextThread(false);
         _encoder.setInjectContextHost(false);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testSafeContextWithUserDefinedContext.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }
@@ -1387,9 +1442,10 @@ public class StenoEncoderTest {
         _encoder.setInjectContextProcess(false);
         _encoder.setInjectContextThread(false);
         _encoder.setInjectContextHost(false);
-        _encoder.init(_baos);
-        _encoder.doEncode(event);
-        final String logOutput = _baos.toString(StandardCharsets.UTF_8.name());
+
+        // CHECKSTYLE.OFF: IllegalInstantiation - This is valid case.
+        final String logOutput = new String(_encoder.encode(event), _encoder.getCharset());
+        // CHECKSTYLE.ON: IllegalInstantiation
         assertOutput("StenoEncoderTest.testSafeContextWithUserDefinedContextWithEncoding.json", logOutput);
         assertMatchesJsonSchema(logOutput);
     }

--- a/src/test/java/com/arpnetworking/logback/serialization/keyvalue/KeyValueSerializationHelperTest.java
+++ b/src/test/java/com/arpnetworking/logback/serialization/keyvalue/KeyValueSerializationHelperTest.java
@@ -43,7 +43,7 @@ public class KeyValueSerializationHelperTest {
         _context.start();
         _baos = new ByteArrayOutputStream();
         _encoder = new KeyValueEncoder();
-        _encoder.init(_baos);
+
         _encoder.setContext(_context);
         _encoder.start();
     }


### PR DESCRIPTION
## Main changes from logback `v1.2.1`

* `Encoder` interface has changed and is no longer expected to handle an `OutputStream`. This simplification allows finer-grain locking resulting in [significantly improved performance](https://docs.google.com/spreadsheets/d/1cpb5D7qnyye4W0RTlHUnXedYK98catNZytYIu5D91m0/edit#gid=0).
* To ensure backward compatibility of configuration files, the `immediateFlush` property set for a `LayoutWrappingEncoder` is propagated to the enclosing `OutputStreamAppender`.

## Main changes from logback `v1.1.10`

Several changes to improve throughput ([see spreadsheet](https://docs.google.com/spreadsheets/d/1cpb5D7qnyye4W0RTlHUnXedYK98catNZytYIu5D91m0/edit?usp=sharing))

* The `ReentrantLock` in `OutputStreamAppender` is now "unfair". In previous versions of logback, a fair lock was used. Fair locks are much slower. Just as importanly, logback has no mandate to influence thread scheduling.
* `FileAppender` now offers the `bufferSize` option. Previously, a fixed-size 8K buffer was used. Increasing the bufferSize, for example to 256K, significantly reduces thread-contention.
* Critical parts of the code now use `COWArrayList`, a custom developed allocation-free lock-free thread-safe implementation of the {@link List} interface. It is optimized for cases where iterations over the list vastly outnumber modifications on the list. It is based on `CopyOnWriteArrayList` but allows allocation-free iterations over the list.
* In `PatternLayoutBase` the same `StringBuilder` is used over and over to reduce memory allocation. This is safe as long as the owning appender guarantees serial access to its layout. In the next version of logback, i.e. 1.2.x, the read-write lock will no longer protect access to the layout and there will be no guarantee of serial access.